### PR TITLE
3. fixed forced copy function in license section

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
 # m <img src="https://img.shields.io/badge/Apache-2.0-blue.svg" alt="License Badge">
 
-
   ## Table of Contents
   * [Description](#description)
   * [Installation](#installation)
@@ -32,11 +31,8 @@
   [Send me a email!](mailto:m)
 
   ## License
-    The project is covered under this license:
 
-    
+The project is covered under this license:
+    [Apache-2.0](https://choosealicense.com/licenses/apache-2.0)
 
-
-    https://choosealicense.com/licenses/apache-2.0
-    
 

--- a/utils/generateMarkdown.js
+++ b/utils/generateMarkdown.js
@@ -13,7 +13,7 @@ function renderLicenseBadge(License) {
 function renderLicenseLink(License) {
   if (License !== "None") {
     const lowercaseLicense = License.toLowerCase();
-    return `https://choosealicense.com/licenses/${lowercaseLicense}`;
+    return `(https://choosealicense.com/licenses/${lowercaseLicense})`;
   } else {
     return "";
   }
@@ -23,17 +23,11 @@ function renderLicenseLink(License) {
 // If there is no license, return an empty string
 function renderLicenseSection(License) {
   if (License !== 'None') {
-    return `## License
-    The project is covered under this license:
-
-    
-
-
-    ${renderLicenseLink(License)}
-    `;
-    } else {
-      return "";
-    }
+    return `## License\n\nThe project is covered under this license:
+    [${License}]${renderLicenseLink(License)}\n`;
+  } else {
+    return "";
+  }
 }
 
 // TODO: Create a function to generate markdown for README


### PR DESCRIPTION
Fixed a problem where i didn't format in a copy function but both vscode and github is forcing one onto the license section. had to add \n on part of the section to clear it.

before:
function renderLicenseSection(License) {
  if (License !== 'None') {
    return `## License
    The project is covered under this license:
    [${License}]${renderLicenseLink(License)}
    `;
    } else {
      return "";
    }
}


after:
function renderLicenseSection(License) {
  if (License !== 'None') {
    return `## License\n\nThe project is covered under this license:
    [${License}]${renderLicenseLink(License)}\n`;
  } else {
    return "";
  }
}